### PR TITLE
Only set target-specific CC and AR for cross-compile

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -1,4 +1,4 @@
-ifeq (eabi,$(findstring eabi,$(TARGET)))
+ifneq ($(HOST),$(TARGET))
 CXX ?= $(TARGET)-g++
 AR ?= $(TARGET)-ar
 else


### PR DESCRIPTION
Checking for "eabi" in $TARGET causes failure to build natively on ARM systems.
