### PR TITLE
Add missing file to the build

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -101,6 +101,7 @@ GLSLANG_CPP_SRC = \
 	src/common/string_utils.cpp \
 	src/common/tls.cpp \
 	src/common/utilities.cpp \
+	src/libANGLE/Platform.cpp \
 	src/third_party/compiler/ArrayBoundsClamper.cpp
 
 


### PR DESCRIPTION
r? @ecoal95 

This missing file meant that calls to the Initialize function couldn't happen. Wasn't a problem in practice for many programs because they didn't have explicit calls to it, so the linker would drop the stub, but on some build invocations on Android, we would have loader errors due to this missing symbol.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ecoal95/angle/4)

<!-- Reviewable:end -->
