### PR TITLE
Add gmake option for freebsd

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,11 +6,20 @@ use std::process::Command;
 use std::env;
 
 
+fn find_make<'a>() -> &'a str {
+    match Command::new("gmake").status() {
+        Ok(_) => "gmake",
+        Err(_) => "make",
+    }
+}
+
 fn main() {
-    assert!(Command::new("make")
+    assert!(Command::new(env::var("MAKE")
+            .unwrap_or_else(|_| find_make().to_owned()))
         .args(&["-R", "-f", "makefile.cargo", &format!("-j{}", env::var("NUM_JOBS").unwrap())])
         .status()
         .unwrap()
         .success());
-    println!("cargo:rustc-flags=-L native={}", env::var("OUT_DIR").unwrap());
+    println!("cargo:rustc-flags=-L native={}",
+             env::var("OUT_DIR").unwrap());
 }


### PR DESCRIPTION
Add gmake for freebsd. `-R` option is not valid for freebsd's version of make. GNU make must be used.

Part of: servo/servo#11625

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/angle/8)

<!-- Reviewable:end -->
