### PR TITLE
Fix shader compilation issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "angle"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["ecoal95 <ecoal95@gmail.com>"]
 description = "GLSL parsing and validation library based on ANGLE"
 license = "MIT"

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -174,11 +174,14 @@ impl ShaderValidator {
 
         let options = SH_VALIDATE | SH_OBJECT_CODE |
                       SH_EMULATE_BUILT_IN_FUNCTIONS | // To workaround drivers
-                      SH_TIMING_RESTRICTIONS |
                       SH_CLAMP_INDIRECT_ARRAY_BOUNDS |
                       SH_INIT_GL_POSITION |
                       SH_ENFORCE_PACKING_RESTRICTIONS |
                       SH_LIMIT_CALL_STACK_DEPTH;
+
+        // Todo(Mortimer): Add SH_TIMING_RESTRICTIONS to options when the implementations gets better
+        // Right now SH_TIMING_RESTRICTIONS it's experimental 
+        // and doesn't support user callable functions in shaders
 
         try!(self.compile(strings, options));
         Ok(self.object_code())

--- a/src/hl.rs
+++ b/src/hl.rs
@@ -180,7 +180,7 @@ impl ShaderValidator {
                       SH_LIMIT_CALL_STACK_DEPTH;
 
         // Todo(Mortimer): Add SH_TIMING_RESTRICTIONS to options when the implementations gets better
-        // Right now SH_TIMING_RESTRICTIONS it's experimental 
+        // Right now SH_TIMING_RESTRICTIONS is experimental 
         // and doesn't support user callable functions in shaders
 
         try!(self.compile(strings, options));


### PR DESCRIPTION
Disable SH_TIMING_RESTRICTIONS compilation flag. It's just a experimental feature and doesn't support basic features like user callable functions in shaders. Almost all the shaders fail to compile because of this.

We can reenable it when the implementation gets better ;)
