### PR TITLE
Update rust-bindgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ build = "build.rs"
 
 [build-dependencies]
 cmake = "0.1"
-bindgen = "0.22.0"
+bindgen = "0.23"


### PR DESCRIPTION
Update rust-bindgen. Fixes a compile crash in OSX: signal: `11, SIGSEGV: invalid memory reference`