### PR TITLE
Fix compile errors when building for Android on macOS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,5 +146,12 @@ if(MSVC)
     -D_SCL_SECURE_NO_WARNINGS)
 endif()
 
+# __STDC_CONSTANT_MACROS is not defined when building for Android
+# on macOS and causes "UINT*_C not declared" C++ compiler errors.
+if ((${CMAKE_SYSTEM_NAME} STREQUAL "Android") AND
+    (${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Darwin"))
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_CONSTANT_MACROS")
+endif()
+
 add_library(angle STATIC ${ANGLE_SOURCES})
 install(TARGETS angle ARCHIVE DESTINATION .)


### PR DESCRIPTION
Without defining  __STDC_CONSTANT_MACROS, I met the following error:

```
In file included from /Users/me/Works/servo/.cargo/git/checkouts/angle-017278ddf8240375/c598aaf/src/glslang-c.cpp:1:0:
/Users/me/Works/servo/.cargo/git/checkouts/angle-017278ddf8240375/c598aaf/include/GLSLANG/ShaderLang.h:75:74: error: 'UINT64_C' was not declared in this scope
 const ShCompileOptions SH_VALIDATE_LOOP_INDEXING             = UINT64_C(1) << 0;
                                                                          ^
```