### PR TITLE
Enable expression complexity limits.

### DIFF
--- a/src/hl.rs
+++ b/src/hl.rs
@@ -198,6 +198,7 @@ impl ShaderValidator {
                       SH_CLAMP_INDIRECT_ARRAY_BOUNDS |
                       SH_INIT_GL_POSITION |
                       SH_ENFORCE_PACKING_RESTRICTIONS |
+                      SH_LIMIT_EXPRESSION_COMPLEXITY |
                       SH_LIMIT_CALL_STACK_DEPTH;
 
         // Todo(Mortimer): Add SH_TIMING_RESTRICTIONS to options when the implementations gets better


### PR DESCRIPTION
Fixes a stack-overflow crash in long-expressions-should-not-crash.html
on newer Mesa, and apparently also on (at least older) NVIDIA drivers.

This defaults to angle's default "256".  Firefox seems to do 1000 for
the NVIDIA bug and not cover Mesa.